### PR TITLE
[feature] git commit miss message value

### DIFF
--- a/gitee/model_single_commit.go
+++ b/gitee/model_single_commit.go
@@ -13,4 +13,5 @@ type SingleCommit struct {
 	Author *GitUser `json:"author,omitempty"`
 	Committer *GitUser `json:"committer,omitempty"`
 	Tree *CommitTree `json:"tree,omitempty"`
+	Message string `json:"message,omitempty"`
 }


### PR DESCRIPTION
gitee api commit response body
<img width="1080" alt="image" src="https://user-images.githubusercontent.com/38621724/161426279-f04dd63b-78ab-4dea-87b4-76e0271ef722.png">

go-gitee response body
<img width="505" alt="image" src="https://user-images.githubusercontent.com/38621724/161426301-4f50c698-70b0-4268-aace-b70e45a26f6e.png">
<img width="423" alt="image" src="https://user-images.githubusercontent.com/38621724/161426315-d59f5b07-f3fb-4e63-b1c9-7f43e4a77a17.png">

miss message 
